### PR TITLE
Removed "..." references to avoid "Unexpected token" errors

### DIFF
--- a/depsolver.js
+++ b/depsolver.js
@@ -193,7 +193,7 @@ module.exports = function depSolver (executable, libs, parallel, cb) {
              * sign those anyways, just ensure to
              * sign them before the app executable
              */
-            finalLibs.unshift(...orphaned);
+            finalLibs.unshift(orphaned);
           }
           cb(null, finalLibs);
         }


### PR DESCRIPTION
$ bin/applesign.js -h
/Users/<user>/node-applesign/depsolver.js:196
            finalLibs.unshift(...orphaned);
                              ^^^

SyntaxError: Unexpected token ...
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:413:25)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/<user>/node-applesign/session.js:10:19)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)